### PR TITLE
Release 1.0.3

### DIFF
--- a/MyCapytain/__init__.py
+++ b/MyCapytain/__init__.py
@@ -10,5 +10,5 @@
 """
 
 __name__ = "MyCapytain"
-__version__ = "1.0.2"
+__version__ = "1.0.3"
 __all__ = ["common", "retrievers", "resources"]

--- a/MyCapytain/common/reference.py
+++ b/MyCapytain/common/reference.py
@@ -10,11 +10,9 @@
 """
 from __future__ import unicode_literals
 
-from collections import defaultdict
 from past.builtins import basestring
 from six import text_type as str
-from builtins import \
-    range, object
+from builtins import range, object
 from copy import copy
 import re
 
@@ -196,8 +194,17 @@ class Reference(object):
             >>>    (a == b) == False
             >>>    (c == b) == True
         """
-        return (isinstance(other, self.__class__)
+        return (isinstance(other, type(self))
                 and self.reference == str(other))
+
+    def __ne__(self, other):
+        """ Inequality checker for Reference object
+
+        :param other: An object to be checked against
+        :rtype: boolean
+        :returns: Equality between other and self
+        """
+        return not self.__eq__(other)
 
     def __model(self):
         """ 3-Tuple model for references
@@ -431,10 +438,18 @@ class URN(object):
         :Example:
             >>>    a = URN(urn="urn:cts:latinLit:phi1294.phi002.perseus-lat2:1.1") 
             >>>    b = URN(urn="urn:cts:latinLit:phi1294.phi002:1.1") 
-            >>>    (b == a) == False # 
+            >>>    (b == a) == False
         """
-        return (isinstance(other, self.__class__)
-                and self.__str__() == str(other))
+        return isinstance(other, type(self)) and str(self) == str(other)
+
+    def __ne__(self, other):
+        """ Inequality checker for Reference object
+
+        :param other: An object to be checked against
+        :rtype: boolean
+        :returns: Equality between other and self
+        """
+        return not self.__eq__(other)
 
     def __str__(self):
         """ Return full initial urn

--- a/MyCapytain/errors.py
+++ b/MyCapytain/errors.py
@@ -15,3 +15,8 @@ class InvalidSiblingRequest(Exception):
     depth, ex. : 1-2.25
     """
     pass
+
+
+class InvalidURN(Exception):
+    """ This error is thrown when URN are not valid
+    """

--- a/MyCapytain/resources/inventory.py
+++ b/MyCapytain/resources/inventory.py
@@ -236,6 +236,7 @@ class Text(inventory.Text):
         :returns: None
         """
         self.xml = xmlparser(resource)
+        self.urn = URN(self.xml.get("urn"))
 
         if self.subtype == "Translation":
             lang = self.xml.get("{http://www.w3.org/XML/1998/namespace}lang")
@@ -344,6 +345,7 @@ class Work(inventory.Work):
         :param type: basestring, etree._Element
         """
         self.xml = xmlparser(resource)
+        self.urn = URN(self.xml.get("urn"))
 
         lang = self.xml.get("{http://www.w3.org/XML/1998/namespace}lang")
         if lang is not None:
@@ -421,10 +423,12 @@ class TextGroup(inventory.TextGroup):
     def parse(self, resource):
         """ Parse a resource 
 
-        :param resource: Element rerpresenting the textgroup
-        :param type: basestring, etree._Element
+        :param resource: Element representing the textgroup
+        :param type: basestring or etree._Element
         """
         self.xml = xmlparser(resource)
+
+        self.urn = URN(self.xml.get("urn"))
 
         for child in self.xml.xpath("ti:groupname", namespaces=NS):
             lg = child.get("{http://www.w3.org/XML/1998/namespace}lang")

--- a/setup.py
+++ b/setup.py
@@ -25,5 +25,16 @@ setup(
     "DOC": ["Sphinx==1.3.1"]
   },
   test_suite="tests",
-  zip_safe=False
+  zip_safe=False,
+  classifiers=[
+    "Development Status :: 5 - Production/Stable",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Education",
+    "Intended Audience :: Information Technology",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
+    "Topic :: Software Development :: Libraries",
+    "Topic :: Text Processing :: Markup :: XML",
+    "Topic :: Text Processing :: General"
+  ]
 )

--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,8 @@ setup(
     "mock==1.3.0",
     "xmlunittest>=0.3.2"
   ],
-  extras_require = {
-    "DOC" : ["Sphinx==1.3.1"]
+  extras_require={
+    "DOC": ["Sphinx==1.3.1"]
   },
   test_suite="tests",
   zip_safe=False


### PR DESCRIPTION
- Added support for .update() on textgroup and work ( Issue #53 )
- Fixed bug in Python 2 where `URN != URN` would not be the same as `not URN == URN`
- Now parsing URN from XML on retrieval of inventory for XML Inventory
- Added len to Work and Textgroup (Returns number of text in object)
- Enhanced documentation
- Added Pypy classifier