### PR TITLE
Added error handling for failed requests to CTS API

### DIFF
--- a/MyCapytain/retrievers/cts5.py
+++ b/MyCapytain/retrievers/cts5.py
@@ -47,6 +47,7 @@ class HttpCtsRetriever(MyCapytain.retrievers.prototypes.CtsRetriever):
             parameters["inv"] = self.inventory
 
         request = requests.get(self.endpoint, params=parameters)
+        request.raise_for_status()
         return request.text
 
     def getCapabilities(self, inventory=None, urn=None):

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ future>=0.16.0
 six>=1.10.0
 xmlunittest>=0.3.2
 rdflib-jsonld>=0.4.0
+responses>=0.8.1

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
   ],
   tests_require=[
     "mock>=2.0.0",
+    "responses>=0.8.1",
     "xmlunittest>=0.3.2"
   ],
   extras_require={

--- a/tests/retrievers/test_cts5.py
+++ b/tests/retrievers/test_cts5.py
@@ -1,5 +1,9 @@
 import unittest
+
+import requests
+import responses
 from mock import patch
+
 from MyCapytain.retrievers.cts5 import *
 
 
@@ -214,3 +218,13 @@ class TestEndpointsCts5(unittest.TestCase):
                     "urn": "urn:1.1"
                 }
             )
+
+    @responses.activate
+    def test_error_handling(self):
+        responses.add(
+            responses.GET,
+            "http://domainname.com/rest/cts?urn=urn%3A1.1&request=GetPassage",
+            body="Internal Server Error", status=500,
+        )
+        with self.assertRaises(requests.HTTPError):
+            self.cts.getTextualNode(textId="urn", subreference="1.1")


### PR DESCRIPTION
On a failed request to CTS the text of the error body is sent. In my experience this is never wanted. Especially once it gets sent in to XML parsing for collections.

Raise an exception right when we know about it to improve debugging information.