### PR TITLE
Explicitly set fallback encoding for CTS API responses

### DIFF
--- a/MyCapytain/retrievers/cts5.py
+++ b/MyCapytain/retrievers/cts5.py
@@ -48,6 +48,8 @@ class HttpCtsRetriever(MyCapytain.retrievers.prototypes.CtsRetriever):
 
         request = requests.get(self.endpoint, params=parameters)
         request.raise_for_status()
+        if request.encoding is None:
+            request.encoding = "utf-8"
         return request.text
 
     def getCapabilities(self, inventory=None, urn=None):

--- a/MyCapytain/retrievers/cts5.py
+++ b/MyCapytain/retrievers/cts5.py
@@ -47,6 +47,7 @@ class HttpCtsRetriever(MyCapytain.retrievers.prototypes.CtsRetriever):
             parameters["inv"] = self.inventory
 
         request = requests.get(self.endpoint, params=parameters)
+        request.raise_for_status()
         return request.text
 
     def getCapabilities(self, inventory=None, urn=None):

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ future>=0.16.0
 six>=1.10.0
 xmlunittest>=0.3.2
 rdflib-jsonld>=0.4.0
+responses>=0.8.1

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
   ],
   tests_require=[
     "mock>=2.0.0",
+    "responses>=0.8.1",
     "xmlunittest>=0.3.2"
   ],
   extras_require={

--- a/tests/retrievers/test_cts5.py
+++ b/tests/retrievers/test_cts5.py
@@ -2,7 +2,7 @@ import unittest
 
 import requests
 import responses
-from mock import patch
+from mock import patch, MagicMock
 
 from MyCapytain.retrievers.cts5 import *
 
@@ -228,3 +228,15 @@ class TestEndpointsCts5(unittest.TestCase):
         )
         with self.assertRaises(requests.HTTPError):
             self.cts.getTextualNode(textId="urn", subreference="1.1")
+
+    @responses.activate
+    def test_encoding(self):
+        """ Ensure retriever falls back to UTF-8 when no encoding is present on responses """
+        response = MagicMock(encoding=None)
+        with patch('requests.get', return_value=response) as patched_get:
+            self.cts.getTextualNode(textId="urn", subreference="1.1")
+            self.assertEqual(response.encoding, "utf-8")
+        response = MagicMock(encoding="latin1")
+        with patch('requests.get', return_value=response) as patched_get:
+            self.cts.getTextualNode(textId="urn", subreference="1.1")
+            self.assertEqual(response.encoding, "latin1")

--- a/tests/retrievers/test_cts5.py
+++ b/tests/retrievers/test_cts5.py
@@ -1,5 +1,9 @@
 import unittest
+
+import requests
+import responses
 from mock import patch
+
 from MyCapytain.retrievers.cts5 import *
 
 
@@ -214,3 +218,13 @@ class TestEndpointsCts5(unittest.TestCase):
                     "urn": "urn:1.1"
                 }
             )
+
+    @responses.activate
+    def test_error_handling(self):
+        responses.add(
+            responses.GET,
+            "http://domainname.com/rest/cts?urn=urn%3A1.1&request=GetPassage",
+            body="Internal Server Error", status=500,
+        )
+        with self.assertRaises(requests.HTTPError):
+            self.cts.getTextualNode(textId="urn", subreference="1.1")


### PR DESCRIPTION
See my commit message for more information.

To avoid merge conflicts this is based on PR #140. That PR should be merged before this one. The diff on this PR will include the changes there.