### PR TITLE
Replace quadratic algorithm in cts.GetValidReff.

### DIFF
--- a/MyCapytain/resources/texts/local/capitains/cts.py
+++ b/MyCapytain/resources/texts/local/capitains/cts.py
@@ -264,7 +264,13 @@ class _SharedMethods(TeiResource):
         passages = [".".join(passage) for passage in passages]
 
         if _debug:
-            duplicates = set([n for n in passages if passages.count(n) > 1])
+            duplicates = set()
+            seen = set()
+            for n in passages:
+                if n in seen:
+                    duplicates.add(n)
+                else:
+                    seen.add(n)
             if len(duplicates) > 0:
                 message = ", ".join(duplicates)
                 warnings.warn(message, DuplicateReference)


### PR DESCRIPTION
When the _debug parameter is set to True, as it is when called
by hooktest, the GetValidReff method for CapitainsCtsText files
used a quadratic algorithm to search for duplicate passage
reference strings. When a large number of passage references
is generated for a document this caused a significant processing
delay.

Instead, use a more verbose but O(N) algorithm.