### PR TITLE
Corrected a problem with siblingsId throwing an IndexError

### DIFF
--- a/MyCapytain/resources/texts/local/capitains/cts.py
+++ b/MyCapytain/resources/texts/local/capitains/cts.py
@@ -659,7 +659,7 @@ class CapitainsCtsPassage(_SharedMethods, PrototypeCtsPassage):
         if start + 1 == len(document_references) or end + 1 == len(document_references):
             # If the passage is already at the end
             _next = None
-        elif end + range_length > len(document_references):
+        elif end + range_length >= len(document_references):
             if start == end:
                 _next = document_references[-1]
             else:

--- a/tests/resources/texts/local/commonTests.py
+++ b/tests/resources/texts/local/commonTests.py
@@ -716,6 +716,10 @@ class CapitainsXmlPassageTests(TestCase):
             self.assertEqual(("1-4", "9-12"), (str(p), str(n)), "Middle node should have right siblings")
             p, n = self.FULL_EPIGRAMMATA.getTextualNode(CtsReference("5-10"), simple=simple).siblingsId
             self.assertEqual(("1-4", "11-14"), (str(p), str(n)), "Middle node should have right siblings")
+            # This test makes sure that siblingsId functions when end + range_length == len(document_references)
+            # Previously when this was the case siblingsId would throw an IndexError
+            p, n = self.FULL_EPIGRAMMATA.getTextualNode(CtsReference("2-8"), simple=simple).siblingsId
+            self.assertEqual(("1-1", "9-14"), (str(p), str(n)), "Middle node should have right siblings")
             # NONE !
             p, n = self.FULL_EPIGRAMMATA.getTextualNode(CtsReference("1-14"), simple=simple).siblingsId
             self.assertEqual((None, None), (p, n), "If whole range, nothing !")


### PR DESCRIPTION
An example of when this error is thrown can be seen in the test that I have added. 
What is happening here is that the `range_length` is 7, `end` is 7, and `len(document_reference)` is 14. That means that `end + range_length == len(document_references)`. That means that the `elif` statement does not fire and it goes to `else`, which errors because it tries to call `document_references[end + range_length]`, which would be `document_references[14]`, which doesn't exist. This change should correct the problem.