### PR TITLE
Relationships among collections are now handled through the resolver

### DIFF
--- a/MyCapytain/resolvers/capitains/local.py
+++ b/MyCapytain/resolvers/capitains/local.py
@@ -16,8 +16,10 @@ from MyCapytain.resolvers.utils import CollectionDispatcher
 from MyCapytain.resources.collections.capitains import XmlCapitainsCollectionMetadata, \
     XmlCapitainsReadableMetadata
 from MyCapytain.resources.collections.cts import XmlCtsCitation
+from MyCapytain.resources.prototypes.metadata import Collection
 from MyCapytain.resources.prototypes.capitains.collection import CapitainsCollectionMetadata
 from MyCapytain.resources.texts.local.capitains.cts import CapitainsCtsText
+from typing import Dict
 
 
 __all__ = [
@@ -63,18 +65,25 @@ class XmlCapitainsLocalResolver(Resolver):
         self._inventory = value
 
     @property
-    def texts(self):
+    def texts(self) -> Dict[str, Collection]:
         """ returns all readable texts
 
         :return: Readable descendants
         :rtype: {str: CapitainsReadableMetadata}
         """
         # Changed to a dictionary to match with the return type for XmlCapitainsCollectionMetadata.texts
-        return {text.id: text for text in self.inventory.readableDescendants}
+        texts = {}
+        for s in self.children.values():
+            for v in s:
+                c = self.id_to_coll[v]
+                if c.readable:
+                    texts[v] = c
+        return texts
 
     def __init__(self, resource, name=None, logger=None, dispatcher=None, autoparse=True):
         """ Initiate the XMLResolver
         """
+        super(XmlCapitainsLocalResolver, self).__init__()
         self.classes = {}
         self.classes.update(type(self).CLASSES)
 

--- a/MyCapytain/resolvers/capitains/local.py
+++ b/MyCapytain/resolvers/capitains/local.py
@@ -83,10 +83,11 @@ class XmlCapitainsLocalResolver(Resolver):
         """ Initiate the XMLResolver
         """
         super(XmlCapitainsLocalResolver, self).__init__()
+        self._inventory = None
         self.classes = {}
         self.classes.update(type(self).CLASSES)
 
-        self._inventory = self.classes["Collection"](name or "defaultTic", resolver=self)
+        self.inventory = self.classes["Collection"](name or "defaultTic", resolver=self)
         self.add_collection(self._inventory.id, self._inventory)
         self.name = name
 

--- a/MyCapytain/resolvers/prototypes.py
+++ b/MyCapytain/resolvers/prototypes.py
@@ -8,7 +8,6 @@
 """
 
 from typing import Tuple, Union, Optional, Dict, Any, Set
-from MyCapytain.resources.prototypes.metadata import Collection
 from MyCapytain.resources.prototypes.text import TextualNode
 from MyCapytain.common.reference import BaseReference, BaseReferenceSet
 from collections import defaultdict
@@ -40,16 +39,14 @@ class Resolver(object):
         self._children = defaultdict(set)
 
     @property
-    def id_to_coll(self) -> Dict[str, Collection]:
+    def id_to_coll(self) -> Dict[str, object]:
         """ Returns a mapping from collection's id to its Collection object"""
         return self._id_to_coll
 
-    def add_collection(self, id: str, collection: Collection):
+    def add_collection(self, id: str, collection: object):
         """ Adds an id to coll mapping to self._id_to_coll"""
         if not isinstance(id, str):
             id = str(id)
-        if not isinstance(collection, Collection):
-            raise TypeError("'collection' must have be of type 'Collection'")
         self._id_to_coll.update({id: collection})
 
     @property
@@ -64,6 +61,7 @@ class Resolver(object):
         if not isinstance(parent_id, str):
             parent_id = str(parent_id)
         self._parents[collection_id].add(parent_id)
+        self.add_child(parent_id, collection_id)
 
     @property
     def children(self) -> Dict[str, Set[str]]:
@@ -78,7 +76,23 @@ class Resolver(object):
             child_id = str(child_id)
         self._children[collection_id].add(child_id)
 
-    def getMetadata(self, objectId: str=None, **filters) -> Collection:
+    @property
+    def texts(self) -> Dict[str, object]:
+        """ returns all readable texts
+
+        :return: Readable descendants
+        :rtype: {str: CapitainsReadableMetadata}
+        """
+        # Changed to a dictionary to match with the return type for XmlCapitainsCollectionMetadata.texts
+        texts = {}
+        for s in self.children.values():
+            for v in s:
+                c = self.id_to_coll[v]
+                if c.readable:
+                    texts[v] = c
+        return texts
+
+    def getMetadata(self, objectId: str=None, **filters) -> object:
         """ Request metadata about a text or a collection
 
         :param objectId: Object Identifier to filter on

--- a/MyCapytain/resolvers/prototypes.py
+++ b/MyCapytain/resolvers/prototypes.py
@@ -7,10 +7,11 @@
 
 """
 
-from typing import Tuple, Union, Optional, Dict, Any
+from typing import Tuple, Union, Optional, Dict, Any, Set
 from MyCapytain.resources.prototypes.metadata import Collection
 from MyCapytain.resources.prototypes.text import TextualNode
 from MyCapytain.common.reference import BaseReference, BaseReferenceSet
+from collections import defaultdict
 
 
 __all__ = [
@@ -24,6 +25,62 @@ class Resolver(object):
     Initiation of resolvers are dependent on the implementation of the prototype
 
     """
+    def __init__(self):
+        """
+        :ivar _id_to_coll: maps a collection id to that collection's object
+        :type _id_to_coll: {str: Collection}
+        :ivar _parents: maps a child id to the ids of its direct parents
+        :type _parents: {str: {str}}
+        :ivar _children: maps a parent id to the ids of its direct descendants, i.e., its children
+        :type _children: {str: {str}}
+
+        """
+        self._id_to_coll = dict()
+        self._parents = defaultdict(set)
+        self._children = defaultdict(set)
+
+    @property
+    def id_to_coll(self) -> Dict[str, Collection]:
+        """ Returns a mapping from collection's id to its Collection object"""
+        return self._id_to_coll
+
+    @id_to_coll.setter
+    def id_to_coll(self, id: str, collection: Collection):
+        """ Adds an id to coll mapping to self._id_to_coll"""
+        if not isinstance(id, str):
+            id = str(id)
+        if not isinstance(collection, Collection):
+            raise TypeError("'collection' must have be of type 'Collection'")
+        self._id_to_coll.update({id: collection})
+
+    @property
+    def parents(self) -> Dict[str, Set[str]]:
+        """ Returns a mapping from a collection's id to the ids of its direct parents"""
+        return self._parents
+
+    @parents.setter
+    def parents(self, collection_id: str, parent_id: str):
+        """ Adds a parent id to the set of a collection's parents"""
+        if not isinstance(collection_id, str):
+            collection_id = str(collection_id)
+        if not isinstance(parent_id, str):
+            parent_id = str(parent_id)
+        self._parents[collection_id].add(parent_id)
+
+    @property
+    def children(self) -> Dict[str, Set[str]]:
+        """ Returns a mapping from a collection's id to the ids of its direct children"""
+        return self._children
+
+    @children.setter
+    def children(self, collection_id: str, child_id: str):
+        """ Adds a child id to the set of a collection's children"""
+        if not isinstance(collection_id, str):
+            collection_id = str(collection_id)
+        if not isinstance(child_id, str):
+            child_id = str(child_id)
+        self._children[collection_id].add(child_id)
+
     def getMetadata(self, objectId: str=None, **filters) -> Collection:
         """ Request metadata about a text or a collection
 

--- a/MyCapytain/resolvers/prototypes.py
+++ b/MyCapytain/resolvers/prototypes.py
@@ -44,8 +44,7 @@ class Resolver(object):
         """ Returns a mapping from collection's id to its Collection object"""
         return self._id_to_coll
 
-    @id_to_coll.setter
-    def id_to_coll(self, id: str, collection: Collection):
+    def add_collection(self, id: str, collection: Collection):
         """ Adds an id to coll mapping to self._id_to_coll"""
         if not isinstance(id, str):
             id = str(id)
@@ -58,8 +57,7 @@ class Resolver(object):
         """ Returns a mapping from a collection's id to the ids of its direct parents"""
         return self._parents
 
-    @parents.setter
-    def parents(self, collection_id: str, parent_id: str):
+    def add_parent(self, collection_id: str, parent_id: str):
         """ Adds a parent id to the set of a collection's parents"""
         if not isinstance(collection_id, str):
             collection_id = str(collection_id)
@@ -72,8 +70,7 @@ class Resolver(object):
         """ Returns a mapping from a collection's id to the ids of its direct children"""
         return self._children
 
-    @children.setter
-    def children(self, collection_id: str, child_id: str):
+    def add_child(self, collection_id: str, child_id: str):
         """ Adds a child id to the set of a collection's children"""
         if not isinstance(collection_id, str):
             collection_id = str(collection_id)

--- a/MyCapytain/resolvers/utils.py
+++ b/MyCapytain/resolvers/utils.py
@@ -16,7 +16,7 @@ class CollectionDispatcher:
     def __init__(self, collection, default_inventory_name=None):
         self.collection = collection
         if default_inventory_name is None:
-            default_inventory_name = list(self.collection.children.values())[0].id
+            default_inventory_name = list(self.collection.children.keys())[0]
         self.__methods__ = [(default_inventory_name, lambda x, **kwargs: True)]
 
     @property

--- a/MyCapytain/resources/collections/capitains.py
+++ b/MyCapytain/resources/collections/capitains.py
@@ -4,6 +4,7 @@ from MyCapytain.common.constants import XPATH_NAMESPACES, Mimetypes, RDF_NAMESPA
 from MyCapytain.resources.prototypes.capitains import collection as capitains
 from rdflib.namespace import DC
 from typing import Union, List, Tuple
+from lxml import etree
 
 XPATH_NAMESPACES.update({'dc': "http://purl.org/dc/elements/1.1/", 'dct': 'http://purl.org/dc/terms/'})
 
@@ -140,13 +141,14 @@ class XmlCapitainsCollectionMetadata(capitains.CapitainsCollectionMetadata):
             identifier = xml.xpath("cpt:identifier", namespaces=XPATH_NAMESPACES)[0].text
         o = cls(identifier=identifier, resolver=resolver)
         resolver = o._resolver
-        o.path = xml.get('path')
-        for t in xml.xpath("dc:type", namespaces=XPATH_NAMESPACES):
-            o.subtype = t.text
         if o.id in resolver.id_to_coll:
             resolver.id_to_coll[o.id].update(o)
         else:
             resolver.add_collection(o.id, o)
+        o = resolver.id_to_coll[o.id]
+        o.path = xml.get('path')
+        for t in xml.xpath("dc:type", namespaces=XPATH_NAMESPACES):
+            o.subtype = t.text
         if parent is not None:
             o.parent = parent
 

--- a/MyCapytain/resources/collections/capitains.py
+++ b/MyCapytain/resources/collections/capitains.py
@@ -82,7 +82,7 @@ class XmlCapitainsReadableMetadata(capitains.CapitainsReadableMetadata):
     @classmethod
     def parse(cls, resource, parent=None, resolver=None):
         xml = xmlparser(resource)
-        o = cls(urn=xml.xpath("cpt:identifier", namespaces=XPATH_NAMESPACES)[0].text, parent=parent, resolver=resolver)
+        o = cls(identifier=xml.xpath("cpt:identifier", namespaces=XPATH_NAMESPACES)[0].text, parent=parent, resolver=resolver)
         resolver = o._resolver
         o.metadata.set(RDF_NAMESPACES.CAPITAINS.identifier, o.id)
         for lang in xml.xpath("dc:language", namespaces=XPATH_NAMESPACES):
@@ -138,7 +138,7 @@ class XmlCapitainsCollectionMetadata(capitains.CapitainsCollectionMetadata):
         # This is for a local collection
         if identifier is None:
             identifier = xml.xpath("cpt:identifier", namespaces=XPATH_NAMESPACES)[0].text
-        o = cls(urn=identifier, resolver=resolver)
+        o = cls(identifier=identifier, resolver=resolver)
         resolver = o._resolver
         o.path = xml.get('path')
         for t in xml.xpath("dc:type", namespaces=XPATH_NAMESPACES):

--- a/MyCapytain/resources/collections/capitains.py
+++ b/MyCapytain/resources/collections/capitains.py
@@ -88,7 +88,8 @@ class XmlCapitainsReadableMetadata(capitains.CapitainsReadableMetadata):
         for lang in xml.xpath("dc:language", namespaces=XPATH_NAMESPACES):
             o.lang = lang.text
         o.path = xml.get('path')
-        o.subtype = xml.xpath("dc:type", namespaces=XPATH_NAMESPACES)[0].text
+        for t in xml.xpath("dc:type", namespaces=XPATH_NAMESPACES):
+            o.subtype = t.text
         resolver.add_collection(o.id, o)
         if parent is not None:
             o.parent = parent
@@ -140,7 +141,8 @@ class XmlCapitainsCollectionMetadata(capitains.CapitainsCollectionMetadata):
         o = cls(urn=identifier, resolver=resolver)
         resolver = o._resolver
         o.path = xml.get('path')
-        o.subtype = [t.text for t in xml.xpath("dc:type", namespaces=XPATH_NAMESPACES)]
+        for t in xml.xpath("dc:type", namespaces=XPATH_NAMESPACES):
+            o.subtype = t.text
         if o.id in resolver.id_to_coll:
             resolver.id_to_coll[o.id].update(o)
         else:

--- a/MyCapytain/resources/collections/capitains.py
+++ b/MyCapytain/resources/collections/capitains.py
@@ -1,10 +1,9 @@
-from MyCapytain.resources.prototypes.metadata import Collection, ResourceCollection
 from MyCapytain.resources.collections.cts import _parse_structured_metadata, XmlCtsCitation
 from MyCapytain.common.utils.xml import xmlparser
 from MyCapytain.common.constants import XPATH_NAMESPACES, Mimetypes, RDF_NAMESPACES
-from MyCapytain.common.reference._capitains_cts import Citation as CitationPrototype
 from MyCapytain.resources.prototypes.capitains import collection as capitains
-from rdflib.namespace import DCTERMS, DC
+from rdflib.namespace import DC
+from typing import Union, List, Tuple
 
 XPATH_NAMESPACES.update({'dc': "http://purl.org/dc/elements/1.1/", 'dct': 'http://purl.org/dc/terms/'})
 
@@ -81,14 +80,16 @@ class XmlCapitainsReadableMetadata(capitains.CapitainsReadableMetadata):
         """
 
     @classmethod
-    def parse(cls, resource, parent=None):
+    def parse(cls, resource, parent=None, resolver=None):
         xml = xmlparser(resource)
-        o = cls(urn=xml.xpath("cpt:identifier", namespaces=XPATH_NAMESPACES)[0].text, parent=parent)
+        o = cls(urn=xml.xpath("cpt:identifier", namespaces=XPATH_NAMESPACES)[0].text, parent=parent, resolver=resolver)
+        resolver = o._resolver
         o.metadata.set(RDF_NAMESPACES.CAPITAINS.identifier, o.id)
         for lang in xml.xpath("dc:language", namespaces=XPATH_NAMESPACES):
             o.lang = lang.text
         o.path = xml.get('path')
         o.subtype = xml.xpath("dc:type", namespaces=XPATH_NAMESPACES)[0].text
+        resolver.add_collection(o.id, o)
         if parent is not None:
             o.parent = parent
         cls.parse_metadata(o, xml)
@@ -113,7 +114,12 @@ class XmlCapitainsCollectionMetadata(capitains.CapitainsCollectionMetadata):
     CLASS_READABLE = XmlCapitainsReadableMetadata
 
     @classmethod
-    def parse(cls, resource, parent=None, _with_children=False, recursive=False):
+    def parse(cls, resource, parent: 'XmlCapitainsCollectionMetadata'=None,
+              _with_children: bool=False, recursive: bool=False,
+              resolver=None) -> Union['XmlCapitainsCollectionMetadata',
+                                      Tuple['XmlCapitainsCollectionMetadata',
+                                            List[Union['XmlCapitainsCollectionMetadata',
+                                                       'XmlCapitainsReadableMetadata']]]]:
         """ Parse a resource
 
         :param resource: Element rerpresenting a collection
@@ -131,9 +137,14 @@ class XmlCapitainsCollectionMetadata(capitains.CapitainsCollectionMetadata):
         # This is for a local collection
         if identifier is None:
             identifier = xml.xpath("cpt:identifier", namespaces=XPATH_NAMESPACES)[0].text
-        o = cls(urn=identifier)
+        o = cls(urn=identifier, resolver=resolver)
+        resolver = o._resolver
         o.path = xml.get('path')
         o.subtype = [t.text for t in xml.xpath("dc:type", namespaces=XPATH_NAMESPACES)]
+        if o.id in resolver.id_to_coll:
+            resolver.id_to_coll[o.id].update(o)
+        else:
+            resolver.add_collection(o.id, o)
         if parent is not None:
             o.parent = parent
 
@@ -151,11 +162,11 @@ class XmlCapitainsCollectionMetadata(capitains.CapitainsCollectionMetadata):
             children = []
             children.extend(_xpathDict(
                 xml=xml, xpath='cpt:members/cpt:collection[@readable="true"]',
-                cls=cls.CLASS_READABLE, parent=o
+                cls=cls.CLASS_READABLE, parent=o, resolver=resolver
             ))
             children.extend(_xpathDict(
                 xml=xml, xpath='cpt:members/cpt:collection[not(@readable="true")]',
-                cls=cls, parent=o, _with_children=recursive, recursive=recursive
+                cls=cls, parent=o, _with_children=recursive, recursive=recursive, resolver=resolver
             ))
             return o, children
         return o

--- a/MyCapytain/resources/prototypes/capitains/collection.py
+++ b/MyCapytain/resources/prototypes/capitains/collection.py
@@ -18,7 +18,7 @@ from collections import defaultdict
 
 from rdflib import RDF, Literal, URIRef
 from rdflib.namespace import DC
-from typing import List, Dict
+from typing import List, Dict, Set
 
 __all__ = [
     "PrototypeCapitainsCollection",
@@ -40,7 +40,6 @@ class PrototypeCapitainsCollection(Collection):
 
     EXPORT_TO = [Mimetypes.PYTHON.ETREE, Mimetypes.XML.GUIDELINES3]
     DEFAULT_EXPORT = Mimetypes.PYTHON.ETREE
-    SUBTYPE = "unknown"
     TYPE_URI = RDF_NAMESPACES.CAPITAINS.term("collection")
     COLLECTION_ATTRIBUTES = ['path', 'readable']
 
@@ -48,7 +47,7 @@ class PrototypeCapitainsCollection(Collection):
         super(PrototypeCapitainsCollection, self).__init__(identifier, resolver)
 
         self._id = str(identifier)
-        self.__subtype__ = self.SUBTYPE
+        self._subtype = set()
         self._parent = list()
 
     @property
@@ -60,23 +59,23 @@ class PrototypeCapitainsCollection(Collection):
         return self._id
 
     @property
-    def subtype(self):
-        """ Subtype of the object
+    def subtype(self) -> Set[str]:
+        """ Subtypes of the object
 
         :return: string representation of subtype
         """
-        return self.__subtype__
+        return self._subtype
 
     @subtype.setter
-    def subtype(self, val):
+    def subtype(self, val: str):
         """ Set the subtype of the object
 
         :param val: the object's subtype
         """
         if isinstance(val, str):
-            self.__subtype__ = val
+            self._subtype.add(val)
         else:
-            self.__subtype__ = str(val)
+            self._subtype.add(str(val))
 
     @property
     def children(self) -> Dict[str, 'PrototypeCapitainsCollection']:
@@ -84,15 +83,6 @@ class PrototypeCapitainsCollection(Collection):
 
         """
         return {x: self._resolver.id_to_coll[x] for x in self._resolver.children[self.id]}
-
-    def _add_member(self, member):
-        """ Does not add member if it already knows it.
-
-        .. warning:: It should not be called !
-
-        :param member: Collection to add to members
-        """
-        self._resolver.add_child(self.id, member.id)
 
     @property
     def parent(self):

--- a/MyCapytain/resources/prototypes/capitains/collection.py
+++ b/MyCapytain/resources/prototypes/capitains/collection.py
@@ -172,7 +172,7 @@ class PrototypeCapitainsCollection(Collection):
         return x
 
     def set_label(self, label, lang):
-        return NotImplementedError('Use obj.metadata.add(DC.title, {}, {}) to add a title to collection'.format(label,
+        raise NotImplementedError('Use obj.metadata.add(DC.title, {}, {}) to add a title to collection'.format(label,
                                                                                                                 lang))
 
     def __getitem__(self, key):
@@ -448,6 +448,7 @@ class CapitainsCollectionMetadata(PrototypeCapitainsCollection):
                 for parent in other_descendant.parent.union(self_descendants[desc_id].parent):
                     self._resolver.id_to_coll[desc_id].parent = self._resolver.id_to_coll[parent]
             else:
+                self._resolver.add_collection(desc_id, other_descendant)
                 new_parents = []
                 for parent in other_descendant.parent:
                     if parent in self._resolver.id_to_coll:
@@ -455,10 +456,11 @@ class CapitainsCollectionMetadata(PrototypeCapitainsCollection):
                         # parent_coll.update(other._resolver.id_to_coll[parent])
                     else:
                         parent_coll = other._resolver.id_to_coll[parent]
+                        self._resolver.add_collection(parent, parent_coll)
                     new_parents.append(parent_coll)
                 other_descendant._parent = []
                 for parent in new_parents:
-                    other_descendant.parent = parent
+                    self._resolver.add_parent(desc_id, parent.id)
 
         return self
 

--- a/MyCapytain/resources/prototypes/capitains/collection.py
+++ b/MyCapytain/resources/prototypes/capitains/collection.py
@@ -12,12 +12,13 @@ from MyCapytain.resources.prototypes.metadata import Collection, ResourceCollect
 from MyCapytain.common.reference._capitains_cts import URN
 from MyCapytain.common.utils.xml import make_xml_node, xmlparser
 from MyCapytain.common.constants import RDF_NAMESPACES, Mimetypes, GRAPH_BINDINGS
-from MyCapytain.errors import InvalidURN
+from MyCapytain.errors import InvalidURN, UnknownCollection
+from MyCapytain.resolvers.prototypes import Resolver
 from collections import defaultdict
 
 from rdflib import RDF, Literal, URIRef
 from rdflib.namespace import DC
-from typing import List
+from typing import List, Dict
 
 __all__ = [
     "PrototypeCapitainsCollection",
@@ -43,8 +44,8 @@ class PrototypeCapitainsCollection(Collection):
     TYPE_URI = RDF_NAMESPACES.CAPITAINS.term("collection")
     COLLECTION_ATTRIBUTES = ['path', 'readable']
 
-    def __init__(self, identifier=""):
-        super(PrototypeCapitainsCollection, self).__init__(identifier)
+    def __init__(self, identifier: str='', resolver: Resolver=None):
+        super(PrototypeCapitainsCollection, self).__init__(identifier, resolver)
 
         self._id = str(identifier)
         self.__subtype__ = self.SUBTYPE
@@ -78,20 +79,20 @@ class PrototypeCapitainsCollection(Collection):
             self.__subtype__ = str(val)
 
     @property
-    def ancestors(self) -> List[Collection]:
-        """ Iterator to find parents of current collection, from closest to furthest
+    def children(self) -> Dict[str, 'PrototypeCapitainsCollection']:
+        """ Dictionary of childrens {Identifier: Collection}
 
-        :rtype: [Collection]
         """
-        p = self.parent
-        parents = []
-        while p != []:
-            parents.extend(p)
-            new_p = []
-            for parent in p:
-                new_p.extend(parent.parent)
-            p = new_p
-        return parents
+        return {x: self._resolver.id_to_coll[x] for x in self._resolver.children[self.id]}
+
+    def _add_member(self, member):
+        """ Does not add member if it already knows it.
+
+        .. warning:: It should not be called !
+
+        :param member: Collection to add to members
+        """
+        self._resolver.add_child(self.id, member.id)
 
     @property
     def parent(self):
@@ -99,7 +100,7 @@ class PrototypeCapitainsCollection(Collection):
 
         :rtype: [Collection]
         """
-        return self._parent
+        return self._resolver.parents[self.id]
 
     @parent.setter
     def parent(self, parent):
@@ -109,12 +110,61 @@ class PrototypeCapitainsCollection(Collection):
         :type parent: Collection
         :return:
         """
-        if parent not in self._parent:
-            self._parent.append(parent)
-            self.graph.add(
-                (self.asNode(), RDF_NAMESPACES.CAPITAINS.parent, parent.asNode())
-            )
-            parent._add_member(self)
+        self.metadata.add(RDF_NAMESPACES.CAPITAINS.parent, URIRef(parent.id))
+        self._resolver.add_parent(self.id, parent.id)
+
+    @property
+    def ancestors(self) -> Dict[str, 'Collection']:
+        """ Iterator to find parents of current collection, from closest to furthest
+
+        :rtype: Generator[:class:`Collection`]
+        """
+        ancestors = set()
+        parents = self.parent
+        ancestors.update(parents)
+        while parents:
+            new_p = set()
+            for parent in parents:
+                parent_coll = self._resolver.id_to_coll[parent]
+                ancestors.update(parent_coll.parent)
+                new_p.update(parent_coll.parent)
+            parents = new_p
+        return {x: self._resolver.id_to_coll[x] for x in ancestors}
+
+    @property
+    def descendants(self) -> Dict[str, 'Collection']:
+        """ Any descendant (no max level) of the collection's item
+
+        :rtype: [Collection]
+        """
+        descendants = set()
+        children = self.children
+        descendants.update(children)
+        while children:
+            new_c = set()
+            for child in children:
+                child_coll = self._resolver.id_to_coll[child]
+                descendants.update(child_coll.children)
+                new_c.update(child_coll.children)
+            children = new_c
+        return {x: self._resolver.id_to_coll[x] for x in descendants}
+
+    @property
+    def readableDescendants(self) -> Dict[str, 'CapitainsReadableMetadata']:
+        """ List of element available which are readable
+
+        :rtype: [Collection]
+        """
+        return {k: v for k, v in self.descendants.items() if v.readable}
+
+    @property
+    def texts(self) -> Dict[str, 'CapitainsReadableMetadata']:
+        """ Texts
+
+        :return: Readable descendants
+        :rtype: {str: CapitainsReadableMetadata}
+        """
+        return self.readableDescendants
 
     def get_label(self, lang=None):
         """ Return label for given lang or any default
@@ -134,6 +184,28 @@ class PrototypeCapitainsCollection(Collection):
     def set_label(self, label, lang):
         return NotImplementedError('Use obj.metadata.add(DC.title, {}, {}) to add a title to collection'.format(label,
                                                                                                                 lang))
+
+    def __getitem__(self, key):
+        """ Retrieve an item by its ID in the tree of a collection
+
+        :param key: Key of the object to delete
+        :return: Collection identified by the item
+        """
+        if key == self.id:
+            return self
+        if key in self.members or key in self.descendants:
+            return self._resolver.id_to_coll[key]
+        raise UnknownCollection("%s is not part of this object" % key)
+
+    def __contains__(self, item):
+        """ Retrieve an item by its ID in the tree of a collection
+
+        :param item:
+        :return: Collection identified by the item
+        """
+        if item == self.id or item in self.descendants:
+            return True
+        return False
 
     def __eq__(self, other):
         if self is other:
@@ -257,8 +329,8 @@ class CapitainsReadableMetadata(ResourceCollection, PrototypeCapitainsCollection
     CAPITAINS_PROPERTIES = [RDF_NAMESPACES.CAPITAINS.identifier, RDF_NAMESPACES.CAPITAINS.parent]
     CAPITAINS_LINKS = [RDF_NAMESPACES.CAPITAINS.about]
 
-    def __init__(self, urn="", parent=None, lang=None):
-        super(CapitainsReadableMetadata, self).__init__(identifier=str(urn))
+    def __init__(self, urn: str="", parent: 'CapitainsCollectionMetadata'=None, lang: str=None, resolver: Resolver=None):
+        super(CapitainsReadableMetadata, self).__init__(identifier=str(urn), resolver=resolver)
         self.resource = None
         self.citation = None
         self.__urn__ = str(urn)
@@ -281,7 +353,7 @@ class CapitainsReadableMetadata(ResourceCollection, PrototypeCapitainsCollection
 
         :rtype: list
         """
-        return list()
+        return dict()
 
     @property
     def descendants(self):
@@ -291,7 +363,7 @@ class CapitainsReadableMetadata(ResourceCollection, PrototypeCapitainsCollection
 
         :rtype: list
         """
-        return list()
+        return dict()
 
     @property
     def readable_siblings(self):
@@ -302,7 +374,7 @@ class CapitainsReadableMetadata(ResourceCollection, PrototypeCapitainsCollection
         """
         sibs = dict()
         for parent in self.parent:
-            sibs.update({x.id: x for x in parent.readableDescendants})
+            sibs.update({k: v for k, v in self._resolver.id_to_coll[parent].readableDescendants.items()})
         sibs.pop(self.id, None)
         return list(sibs.values())
 
@@ -336,22 +408,11 @@ class CapitainsCollectionMetadata(PrototypeCapitainsCollection):
     EXPORT_TO = [Mimetypes.XML.GUIDELINES3]
     CAPITAINS_PROPERTIES = [RDF_NAMESPACES.CAPITAINS.title]
 
-    def __init__(self, urn=None, parent=None):
-        super(CapitainsCollectionMetadata, self).__init__(identifier=str(urn))
-        self.__urn__ = str(urn)
-        self.__children__ = defaultdict(CapitainsReadableMetadata)
+    def __init__(self, urn: str=None, parent: 'CapitainsCollectionMetadata'=None, resolver: Resolver=None):
+        super(CapitainsCollectionMetadata, self).__init__(identifier=str(urn), resolver=resolver)
 
         if parent is not None:
             self.parent = parent
-
-    @property
-    def texts(self):
-        """ Texts
-
-        :return: Readable descendants
-        :rtype: {str: CapitainsReadableMetadata}
-        """
-        return {item.id: item for item in self.readableDescendants}
 
     @property
     def collections(self):
@@ -360,7 +421,7 @@ class CapitainsCollectionMetadata(PrototypeCapitainsCollection):
         :return: List of sub-collections
         :rtype: {str: CapitainsCollectionMetadata}
         """
-        return {collection.id: collection for collection in self.members if collection.readable is False}
+        return {k: v for k, v in self.children.items() if v.readable is False}
 
     @property
     def lang(self):
@@ -370,7 +431,7 @@ class CapitainsCollectionMetadata(PrototypeCapitainsCollection):
         """
         return None
 
-    def update(self, other):
+    def update(self, other: 'CapitainsCollectionMetadata') -> 'CapitainsCollectionMetadata':
         """ Merge two CapitainsCollectionMetadata Objects.
 
         - Original (left Object) keeps his parent.
@@ -387,22 +448,24 @@ class CapitainsCollectionMetadata(PrototypeCapitainsCollection):
             raise InvalidURN("Cannot add CapitainsCollectionMetadata %s to CapitainsCollectionMetadata %s " % (self.urn, other.urn))
 
         # This is necessary because self.texts cannot just call self.children since not all children will be readable
-        self_descendants = {x.id: x for x in self.descendants}
+        self_descendants = {k: v for k, v in self.descendants.items()}
         # The sorting here is to make sure that the new descendants that are added to self will be processed first.
         # This is so that a descendant in other that is also in self but has a different parent in other will have its parent attribute correctly expanded.
-        for other_descendant in sorted(other.descendants, key=lambda x: x.id in self_descendants.keys()):
-            if other_descendant.id in self_descendants.keys():
+        for desc_id, other_descendant in sorted(other.descendants.items(), key=lambda x: x[0] in self_descendants.keys()):
+            if desc_id in self_descendants.keys():
                 if other_descendant.readable is False:
-                    self[other_descendant.id].update(other_descendant)
-                for parent in other_descendant.parent + self_descendants[other_descendant.id].parent:
-                    self[other_descendant.id].parent = parent
+                    self._resolver.id_to_coll[desc_id].update(other_descendant)
+                for parent in other_descendant.parent.union(self_descendants[desc_id].parent):
+                    self._resolver.id_to_coll[desc_id].parent = self._resolver.id_to_coll[parent]
             else:
                 new_parents = []
                 for parent in other_descendant.parent:
-                    if parent.id in self_descendants.keys() or parent.id == self.id:
-                        new_parents.append(self[parent.id])
+                    if parent in self._resolver.id_to_coll:
+                        parent_coll = self._resolver.id_to_coll[parent]
+                        # parent_coll.update(other._resolver.id_to_coll[parent])
                     else:
-                        new_parents.append(parent)
+                        parent_coll = other._resolver.id_to_coll[parent]
+                    new_parents.append(parent_coll)
                 other_descendant._parent = []
                 for parent in new_parents:
                     other_descendant.parent = parent

--- a/MyCapytain/resources/prototypes/capitains/collection.py
+++ b/MyCapytain/resources/prototypes/capitains/collection.py
@@ -319,11 +319,11 @@ class CapitainsReadableMetadata(ResourceCollection, PrototypeCapitainsCollection
     CAPITAINS_PROPERTIES = [RDF_NAMESPACES.CAPITAINS.identifier, RDF_NAMESPACES.CAPITAINS.parent]
     CAPITAINS_LINKS = [RDF_NAMESPACES.CAPITAINS.about]
 
-    def __init__(self, urn: str="", parent: 'CapitainsCollectionMetadata'=None, lang: str=None, resolver: Resolver=None):
-        super(CapitainsReadableMetadata, self).__init__(identifier=str(urn), resolver=resolver)
+    def __init__(self, identifier: str= "", parent: 'CapitainsCollectionMetadata'=None, lang: str=None, resolver: Resolver=None):
+        super(CapitainsReadableMetadata, self).__init__(identifier=str(identifier), resolver=resolver)
         self.resource = None
         self.citation = None
-        self.__urn__ = str(urn)
+        self.__urn__ = str(identifier)
         self.docname = None
         self.validate = None
         self.lang = lang
@@ -398,8 +398,8 @@ class CapitainsCollectionMetadata(PrototypeCapitainsCollection):
     EXPORT_TO = [Mimetypes.XML.GUIDELINES3]
     CAPITAINS_PROPERTIES = [RDF_NAMESPACES.CAPITAINS.title]
 
-    def __init__(self, urn: str=None, parent: 'CapitainsCollectionMetadata'=None, resolver: Resolver=None):
-        super(CapitainsCollectionMetadata, self).__init__(identifier=str(urn), resolver=resolver)
+    def __init__(self, identifier: str=None, parent: 'CapitainsCollectionMetadata'=None, resolver: Resolver=None):
+        super(CapitainsCollectionMetadata, self).__init__(identifier=str(identifier), resolver=resolver)
 
         if parent is not None:
             self.parent = parent

--- a/MyCapytain/resources/prototypes/metadata.py
+++ b/MyCapytain/resources/prototypes/metadata.py
@@ -13,6 +13,7 @@ from MyCapytain.common.utils import literal_to_dict, Subgraph
 from MyCapytain.common.constants import RDF_NAMESPACES, RDFLIB_MAPPING, Mimetypes, get_graph
 from MyCapytain.common.base import Exportable
 from MyCapytain.common.reference import BaseCitationSet
+from MyCapytain.resolvers.prototypes import Resolver
 from rdflib import URIRef, RDF, Literal, Graph, RDFS
 from rdflib.namespace import SKOS, DC, DCTERMS
 from typing import List
@@ -48,7 +49,7 @@ class Collection(Exportable):
     MODEL_URI = URIRef(RDF_NAMESPACES.DTS.collection)
     EXPORT_TO = [Mimetypes.JSON.LD, Mimetypes.JSON.DTS.Std, Mimetypes.XML.RDF]
 
-    def __init__(self, identifier="", *args, **kwargs):
+    def __init__(self, identifier: str="", resolver: Resolver=None, *args, **kwargs):
         super(Collection, self).__init__(identifier, *args, **kwargs)
         self._graph = get_graph()
 
@@ -60,6 +61,9 @@ class Collection(Exportable):
 
         self._parent = None
         self._children = {}
+        if resolver is None:
+            resolver = Resolver()
+        self._resolver = resolver
 
     def __repr__(self):
         return "%s(%s)#%s" % (self.__class__.__name__, self.id, id(self))

--- a/MyCapytain/resources/prototypes/text.py
+++ b/MyCapytain/resources/prototypes/text.py
@@ -15,7 +15,6 @@ from MyCapytain.common.reference import Citation, NodeId, BaseReference, BaseRef
 from MyCapytain.common.metadata import Metadata
 from MyCapytain.common.constants import Mimetypes, get_graph, RDF_NAMESPACES
 from MyCapytain.common.base import Exportable
-from MyCapytain.resources.prototypes.metadata import Collection
 
 
 __all__ = [

--- a/tests/resolvers/cts/test_local.py
+++ b/tests/resolvers/cts/test_local.py
@@ -496,10 +496,6 @@ class TextXMLFolderResolver(TestCase):
             metadata.parent, CtsTextgroupMetadata,
             "First parent should be CtsTextgroupMetadata"
         )
-        self.assertIsInstance(
-            metadata.ancestors[0], CtsTextgroupMetadata,
-            "First parent should be CtsTextgroupMetadata"
-        )
         self.assertEqual(
             len(metadata.export(output=Mimetypes.PYTHON.ETREE).xpath(
                 "//ti:edition[@urn='urn:cts:latinLit:phi1294.phi002.perseus-lat2']", namespaces=XPATH_NAMESPACES)), 1,

--- a/tests/resolvers/cts/test_local.py
+++ b/tests/resolvers/cts/test_local.py
@@ -453,6 +453,8 @@ class TextXMLFolderResolver(TestCase):
             len(metadata.readableDescendants), 26,
             "There should be as many readable descendants as there is edition, translation, commentary (26 ed+tr+cm)"
         )
+        self.assertEqual(len(self.resolver.texts), 26,
+                         'Calling texts should return all readable collections in the resolver.')
         self.assertEqual(
             len([x for x in metadata.readableDescendants if isinstance(x, TextMetadata)]), 26,
             "There should be 24 editions + 1 translation + 1 commentary in readableDescendants"

--- a/tests/resolvers/guidelines_v3/test_local.py
+++ b/tests/resolvers/guidelines_v3/test_local.py
@@ -94,28 +94,8 @@ class TestXMLFolderResolverBehindTheScene(TestCase):
             "General no filter works"
         )
         self.assertEqual(
-            len(Repository._get_text_metadata(category="cts:edition")[0]), 17,
-            "Type filter works"
-        )
-        self.assertEqual(
-            len(Repository._get_text_metadata(category="cts:commentary")[0]), 1,
-            "Type filter works"
-        )
-        self.assertEqual(
             len(Repository._get_text_metadata(lang="deu")[0]), 2,
             "Filtering on language works"
-        )
-        self.assertEqual(
-            len(Repository._get_text_metadata(category="cts:edition", lang="deu")[0]), 1,
-            "Type filter + lang works"
-        )
-        self.assertEqual(
-            len(Repository._get_text_metadata(category="cts:translation", lang="deu")[0]), 1,
-            "Type filter + lang works"
-        )
-        self.assertEqual(
-            len(Repository._get_text_metadata(category="cts:commentary", lang="fre")[0]), 1,
-            "Type filter + lang works"
         )
         self.assertEqual(
             len(Repository._get_text_metadata(page=1, limit=2, pagination=True)[0]), 2,
@@ -126,15 +106,15 @@ class TestXMLFolderResolverBehindTheScene(TestCase):
             "Pagination works without other filters at list end"
         )
         self.assertEqual(
-            len(Repository._get_text_metadata(urn="urn:cts:formulae:passau")[0]), 7,
+            len(Repository._get_text_metadata(id="urn:cts:formulae:passau")[0]), 7,
             "URN Filtering works. 7 texts should be found in Passau."
         )
         self.assertEqual(
-            len(Repository._get_text_metadata(urn="a:different.identifier")[0]), 5,
+            len(Repository._get_text_metadata(id="a:different.identifier")[0]), 5,
             "URN Filtering works. 5 texts should be found in a:different.identifier"
         )
         self.assertEqual(
-            len(Repository._get_text_metadata(urn="urn:cts:formulae:passau.heuwieser0073.lat005")[0]), 1,
+            len(Repository._get_text_metadata(id="urn:cts:formulae:passau.heuwieser0073.lat005")[0]), 1,
             "Complete URN filtering works"
         )
 
@@ -161,7 +141,7 @@ class TestXMLFolderResolverBehindTheScene(TestCase):
         """ Check Get Capabilities latinLit data"""
         Repository = XmlCapitainsLocalResolver(["./tests/testing_data/guidelines_v3_missing"])
         self.assertEqual(
-            len(Repository._get_text_metadata(urn="urn:cts:formulae:passau.heuwieser0073.lat005")[0]), 0,
+            len(Repository._get_text_metadata(id="urn:cts:formulae:passau.heuwieser0073.lat005")[0]), 0,
             "Texts without citations were ignored"
         )
 

--- a/tests/resolvers/guidelines_v3/test_local.py
+++ b/tests/resolvers/guidelines_v3/test_local.py
@@ -4,16 +4,15 @@ from __future__ import unicode_literals
 
 from MyCapytain.resolvers.capitains.local import XmlCapitainsLocalResolver
 from MyCapytain.common.constants import XPATH_NAMESPACES, Mimetypes, RDF_NAMESPACES, get_graph
-from MyCapytain.common.reference._capitains_cts import CtsReference, URN
-from MyCapytain.errors import InvalidURN, UnknownObjectError, UndispatchedTextError
+from MyCapytain.common.reference._capitains_cts import CtsReference
+from MyCapytain.errors import UnknownObjectError, UndispatchedTextError
 from MyCapytain.resources.prototypes.metadata import Collection
 from MyCapytain.resources.collections.capitains import XmlCapitainsCollectionMetadata
 from MyCapytain.resources.prototypes.capitains.collection import CapitainsCollectionMetadata, CapitainsReadableMetadata
 from MyCapytain.resources.prototypes.cts.text import PrototypeCtsPassage
 from MyCapytain.resolvers.utils import CollectionDispatcher
 from unittest import TestCase
-from rdflib.namespace import DC, DCTERMS
-from rdflib import RDFS
+from rdflib.namespace import DC
 
 
 class TestXMLFolderResolverBehindTheScene(TestCase):
@@ -221,6 +220,8 @@ class TextXMLFolderResolver(TestCase):
             self.resolver.getTextualNode("urn:cts:formulae:passau.heuwieser0073", "2")
         with self.assertRaises(UnknownObjectError):
             self.resolver.getTextualNode("urn:cts:formulae:passau", "2")
+        with self.assertRaises(UnknownObjectError):
+            self.resolver.getTextualNode({"urn:cts:formulae:passau"}, "2")
 
     def test_getPassage_subreference(self):
         """ Test that we can get a subreference text passage"""

--- a/tests/resources/collections/test_capitains.py
+++ b/tests/resources/collections/test_capitains.py
@@ -574,6 +574,8 @@ class TestXMLImplementation(unittest.TestCase, xmlunittest.XmlTestMixin):
             len(TG3["urn:cts:formulae:elexicon.abbas"]), 3,
             "There should be 3 texts in work"
         )
+        self.assertEqual(TG3["urn:cts:formulae:elexicon.abbas"].subtype, {'cts:work'},
+                         'The type of object should be correct.')
 
     def test_addition_textgroup(self):
         """ Test merging two textgroups together """

--- a/tests/resources/collections/test_capitains.py
+++ b/tests/resources/collections/test_capitains.py
@@ -887,14 +887,13 @@ xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dts="https://w3id.
             "The repeated text in both collections should be the same object."
         )
 
-
     def test_wrong_urn_addition_work_textgroup(self):
         """ Checks that we cannot add work or textgroup with different URN"""
         from MyCapytain.errors import InvalidURN
         self.assertRaises(
             TypeError,
-            lambda x: XmlCapitainsCollectionMetadata(identifier="urn:cts:latinLit:phi1294.phi002").update(XmlCapitainsReadableMetadata(urn="urn:cts:latinLit:phi1297.phi002")),
-            "Addition of different work with different URN should fail"
+            lambda x: XmlCapitainsCollectionMetadata(identifier="urn:cts:latinLit:phi1294.phi002").update(XmlCapitainsReadableMetadata(identifier="urn:cts:latinLit:phi1297.phi002")),
+            "Addition of readable to non-readable should fail"
         )
         self.assertRaises(
             InvalidURN,

--- a/tests/resources/collections/test_capitains.py
+++ b/tests/resources/collections/test_capitains.py
@@ -576,6 +576,14 @@ class TestXMLImplementation(unittest.TestCase, xmlunittest.XmlTestMixin):
         )
         self.assertEqual(TG3["urn:cts:formulae:elexicon.abbas"].subtype, {'cts:work'},
                          'The type of object should be correct.')
+        TG3["urn:cts:formulae:elexicon.abbas"].subtype = XmlCapitainsCollectionMetadata
+        self.assertEqual(TG3["urn:cts:formulae:elexicon.abbas"].subtype,
+                         {'cts:work', "<class 'MyCapytain.resources.collections.capitains.XmlCapitainsCollectionMetadata'>"},
+                         'The type of object should be correct.')
+        self.assertEqual(TG3["urn:cts:formulae:elexicon.abbas.fre001"].descendants, dict(),
+                         'The descendants of a readable object should return an empty dictionary.')
+        self.assertEqual(str(TG3["urn:cts:formulae:elexicon.abbas.fre001"].get_title()), 'Abbas, abbatissa (fre)',
+                         'Title should be correct.')
 
     def test_addition_textgroup(self):
         """ Test merging two textgroups together """

--- a/tests/resources/collections/test_capitains.py
+++ b/tests/resources/collections/test_capitains.py
@@ -956,6 +956,11 @@ xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dts="https://w3id.
         coll3 = XmlCapitainsCollectionMetadata(identifier='other')
         self.assertNotEqual(coll1, coll3, 'Collections with different IDs should not be equal')
 
+    def test_init_coll_with_parent(self):
+        """ Make sure that a collection that is initiated with a parent has that parent added to its resolver"""
+        coll1 = XmlCapitainsCollectionMetadata(identifier='id', parent=XmlCapitainsCollectionMetadata(identifier='ID'))
+        self.assertEqual(coll1.parent, {'ID'})
+
 
 class TestCitation(unittest.TestCase):
     def test_empty(self):

--- a/tests/resources/collections/test_capitains.py
+++ b/tests/resources/collections/test_capitains.py
@@ -941,6 +941,14 @@ xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dts="https://w3id.
             ["A great charter!"]
         )
 
+    def test_collection_equality(self):
+        """ Make sure that the equality of two collections is correctly returned"""
+        coll1 = XmlCapitainsCollectionMetadata(urn='ID')
+        coll2 = XmlCapitainsCollectionMetadata(urn='ID')
+        self.assertEqual(coll1, coll2, 'Collections wih the same IDs should be equal')
+        coll3 = XmlCapitainsCollectionMetadata(urn='other')
+        self.assertNotEqual(coll1, coll3, 'Collections with different IDs should not be equal')
+
 
 class TestCitation(unittest.TestCase):
     def test_empty(self):

--- a/tests/resources/collections/test_capitains.py
+++ b/tests/resources/collections/test_capitains.py
@@ -770,6 +770,8 @@ class TestXMLImplementation(unittest.TestCase, xmlunittest.XmlTestMixin):
             len(TI3["default"]), 2,
             "There should be 2 texts in inventory"
         )
+        self.assertTrue("urn:cts:formulae:salzburg.hauthaler-a0100" in TI1)
+        self.assertFalse("urn:cts:formulae:elexicon" in TI2)
 
     def test_additions_inventory(self):
         """ Test merging two partially overlapping inventories"""
@@ -960,6 +962,8 @@ xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dts="https://w3id.
         """ Make sure that a collection that is initiated with a parent has that parent added to its resolver"""
         coll1 = XmlCapitainsCollectionMetadata(identifier='id', parent=XmlCapitainsCollectionMetadata(identifier='ID'))
         self.assertEqual(coll1.parent, {'ID'})
+        self.assertEqual(coll1._resolver.parents, {'id': {'ID'}})
+        self.assertEqual(coll1._resolver.children, {'ID': {'id'}})
 
 
 class TestCitation(unittest.TestCase):

--- a/tests/resources/collections/test_capitains.py
+++ b/tests/resources/collections/test_capitains.py
@@ -893,13 +893,13 @@ xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dts="https://w3id.
         from MyCapytain.errors import InvalidURN
         self.assertRaises(
             TypeError,
-            lambda x: XmlCapitainsCollectionMetadata(urn="urn:cts:latinLit:phi1294.phi002").update(XmlCapitainsReadableMetadata(urn="urn:cts:latinLit:phi1297.phi002")),
+            lambda x: XmlCapitainsCollectionMetadata(identifier="urn:cts:latinLit:phi1294.phi002").update(XmlCapitainsReadableMetadata(urn="urn:cts:latinLit:phi1297.phi002")),
             "Addition of different work with different URN should fail"
         )
         self.assertRaises(
             InvalidURN,
-            lambda x: XmlCapitainsCollectionMetadata(urn="urn:cts:latinLit:phi1294").update(
-                XmlCapitainsCollectionMetadata(urn="urn:cts:latinLit:phi1297")),
+            lambda x: XmlCapitainsCollectionMetadata(identifier="urn:cts:latinLit:phi1294").update(
+                XmlCapitainsCollectionMetadata(identifier="urn:cts:latinLit:phi1297")),
             "Addition of different work with different URN should fail"
         )
 
@@ -951,10 +951,10 @@ xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dts="https://w3id.
 
     def test_collection_equality(self):
         """ Make sure that the equality of two collections is correctly returned"""
-        coll1 = XmlCapitainsCollectionMetadata(urn='ID')
-        coll2 = XmlCapitainsCollectionMetadata(urn='ID')
+        coll1 = XmlCapitainsCollectionMetadata(identifier='ID')
+        coll2 = XmlCapitainsCollectionMetadata(identifier='ID')
         self.assertEqual(coll1, coll2, 'Collections wih the same IDs should be equal')
-        coll3 = XmlCapitainsCollectionMetadata(urn='other')
+        coll3 = XmlCapitainsCollectionMetadata(identifier='other')
         self.assertNotEqual(coll1, coll3, 'Collections with different IDs should not be equal')
 
 

--- a/tests/resources/collections/test_cts.py
+++ b/tests/resources/collections/test_cts.py
@@ -205,6 +205,7 @@ class TestXMLImplementation(unittest.TestCase, xmlunittest.XmlTestMixin):
         """ Tests CtsTextInventoryMetadata parses without errors """
         TI = XmlCtsTextInventoryMetadata.parse(resource=self.getCapabilities)
         self.assertGreater(len(TI.textgroups), 0)
+        self.assertEqual(TI['thibault3'], TI)
 
     def test_xml_TextInventory_GetItem(self):
         """ Test access through getItem obj[urn] """


### PR DESCRIPTION
Note that all relationship methods (e.g., parent, ancestors, children, descendants) should now return dictionaries in the form {id: collection_object} for the Guidelines 3 resolver. This has also been implemented on the default `Resolver` prototype but the Guidelines 2 objects do not make use of this to keep track of relationships. There, these are taken care of in the `_parent` and `_children` ivars on the objects themselves. This means that this itself should not be a breaking change for those using MyCapytain for their guidelines 2 collections.